### PR TITLE
Remove null service protections from pipes

### DIFF
--- a/src/CleanArchitecture.Mediator/Internal/AuthenticationPipe.cs
+++ b/src/CleanArchitecture.Mediator/Internal/AuthenticationPipe.cs
@@ -16,7 +16,7 @@ namespace CleanArchitecture.Mediator.Internal
             NextPipeHandleAsync nextPipeHandle,
             CancellationToken cancellationToken)
             => outputPort is IAuthenticationFailureOutputPort _OutputPort
-                && serviceFactory.GetService<IPrincipalAccessor>()?.Principal == null
+                && serviceFactory.GetService<IPrincipalAccessor>().Principal == null
                 ? _OutputPort.PresentAuthenticationFailureAsync(cancellationToken)
                 : nextPipeHandle();
 

--- a/src/CleanArchitecture.Mediator/Internal/AuthorisationPolicyValidationPipe.cs
+++ b/src/CleanArchitecture.Mediator/Internal/AuthorisationPolicyValidationPipe.cs
@@ -19,7 +19,7 @@ namespace CleanArchitecture.Mediator.Internal
             CancellationToken cancellationToken)
         {
             var _Validator = serviceFactory.GetService<IAuthorisationPolicyValidator<TInputPort, TPolicyFailure>>();
-            if (_Validator != null && !await _Validator.ValidateAsync(inputPort, out var _PolicyFailure, serviceFactory, cancellationToken).ConfigureAwait(false))
+            if (!await _Validator.ValidateAsync(inputPort, out var _PolicyFailure, serviceFactory, cancellationToken).ConfigureAwait(false))
             {
                 await outputPort.PresentAuthorisationPolicyFailureAsync(_PolicyFailure, cancellationToken).ConfigureAwait(false);
                 return;

--- a/src/CleanArchitecture.Mediator/Internal/InputPortValidationPipe.cs
+++ b/src/CleanArchitecture.Mediator/Internal/InputPortValidationPipe.cs
@@ -19,7 +19,7 @@ namespace CleanArchitecture.Mediator.Internal
             CancellationToken cancellationToken)
         {
             var _Validator = serviceFactory.GetService<IInputPortValidator<TInputPort, TValidationFailure>>();
-            if (_Validator != null && !await _Validator.ValidateAsync(inputPort, out var _ValidationFailure, serviceFactory, cancellationToken))
+            if (!await _Validator.ValidateAsync(inputPort, out var _ValidationFailure, serviceFactory, cancellationToken))
             {
                 await outputPort.PresentInputPortValidationFailureAsync(_ValidationFailure, cancellationToken).ConfigureAwait(false);
                 return;

--- a/src/CleanArchitecture.Mediator/Internal/InteractorInvocationPipe.cs
+++ b/src/CleanArchitecture.Mediator/Internal/InteractorInvocationPipe.cs
@@ -16,7 +16,7 @@ namespace CleanArchitecture.Mediator.Internal
             NextPipeHandleAsync nextPipeHandle,
             CancellationToken cancellationToken)
             => serviceFactory
-                .GetService<IInteractor<TInputPort, TOutputPort>>()?
+                .GetService<IInteractor<TInputPort, TOutputPort>>()
                 .HandleAsync(inputPort, outputPort, serviceFactory, cancellationToken)
                     ?? Task.CompletedTask;
 

--- a/src/CleanArchitecture.Mediator/Internal/LicencePolicyValidationPipe.cs
+++ b/src/CleanArchitecture.Mediator/Internal/LicencePolicyValidationPipe.cs
@@ -19,7 +19,7 @@ namespace CleanArchitecture.Mediator.Internal
             CancellationToken cancellationToken)
         {
             var _Validator = serviceFactory.GetService<ILicencePolicyValidator<TInputPort, TPolicyFailure>>();
-            if (_Validator != null && !await _Validator.ValidateAsync(inputPort, out var _PolicyFailure, serviceFactory, cancellationToken).ConfigureAwait(false))
+            if (!await _Validator.ValidateAsync(inputPort, out var _PolicyFailure, serviceFactory, cancellationToken).ConfigureAwait(false))
             {
                 await outputPort.PresentLicencePolicyFailureAsync(_PolicyFailure, cancellationToken).ConfigureAwait(false);
                 return;

--- a/test/CleanArchitecture.Mediator.Tests/Unit/Internal/AuthenticationPipeTests.cs
+++ b/test/CleanArchitecture.Mediator.Tests/Unit/Internal/AuthenticationPipeTests.cs
@@ -1,5 +1,7 @@
 ﻿using CleanArchitecture.Mediator.Internal;
+using FluentAssertions;
 using Moq;
+using System;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Xunit;
@@ -56,16 +58,16 @@ public class AuthenticationPipeTests
     }
 
     [Fact]
-    public async Task InvokeAsync_PrincipalAccessorHasNotBeenRegistered_StopsWithAuthenticationFailure()
+    public async Task InvokeAsync_PrincipalAccessorHasNotBeenRegistered_InvocationFails()
     {
         // Arrange
         this.m_MockServiceFactory.Reset();
 
         // Act
-        await this.m_Pipe.InvokeAsync(this.m_InputPort, this.m_MockOutputPort.Object, this.m_MockServiceFactory.Object, this.m_MockNextPipeHandle.Object, default);
+        var _Exception = await Record.ExceptionAsync(() => this.m_Pipe.InvokeAsync(this.m_InputPort, this.m_MockOutputPort.Object, this.m_MockServiceFactory.Object, this.m_MockNextPipeHandle.Object, default));
 
         // Assert
-        this.m_MockOutputPort.Verify(mock => mock.PresentAuthenticationFailureAsync(default), Times.Once());
+        _ = _Exception.Should().BeOfType<NullReferenceException>();
 
         this.m_MockNextPipeHandle.VerifyNoOtherCalls();
         this.m_MockOutputPort.VerifyNoOtherCalls();

--- a/test/CleanArchitecture.Mediator.Tests/Unit/Internal/AuthorisationPolicyValidationPipe.csTests.cs
+++ b/test/CleanArchitecture.Mediator.Tests/Unit/Internal/AuthorisationPolicyValidationPipe.csTests.cs
@@ -1,5 +1,7 @@
 ﻿using CleanArchitecture.Mediator.Internal;
+using FluentAssertions;
 using Moq;
+using System;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -48,16 +50,16 @@ public class AuthorisationPolicyValidationPipeTests
     #region - - - - - - InvokeAsync Tests - - - - - -
 
     [Fact]
-    public async Task InvokeAsync_ValidatorHasNotBeenRegistered_MovesToNextPipe()
+    public async Task InvokeAsync_ValidatorHasNotBeenRegistered_InvocationFails()
     {
         // Arrange
         this.m_MockServiceFactory.Reset();
 
         // Act
-        await this.m_Pipe.InvokeAsync(this.m_InputPort, this.m_MockOutputPort.Object, this.m_MockServiceFactory.Object, this.m_MockNextPipeHandle.Object, default);
+        var _Exception = await Record.ExceptionAsync(() => this.m_Pipe.InvokeAsync(this.m_InputPort, this.m_MockOutputPort.Object, this.m_MockServiceFactory.Object, this.m_MockNextPipeHandle.Object, default));
 
         // Assert
-        this.m_MockNextPipeHandle.Verify(mock => mock.Invoke(), Times.Once());
+        _ = _Exception.Should().BeOfType<NullReferenceException>();
 
         this.m_MockAuthorisationPolicyValidator.VerifyNoOtherCalls();
         this.m_MockNextPipeHandle.VerifyNoOtherCalls();

--- a/test/CleanArchitecture.Mediator.Tests/Unit/Internal/InputPortValidationPipeTests.cs
+++ b/test/CleanArchitecture.Mediator.Tests/Unit/Internal/InputPortValidationPipeTests.cs
@@ -1,5 +1,7 @@
 ﻿using CleanArchitecture.Mediator.Internal;
+using FluentAssertions;
 using Moq;
+using System;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -48,16 +50,16 @@ public class InputPortValidationPipeTests
     #region - - - - - - InvokeAsync Tests - - - - - -
 
     [Fact]
-    public async Task InvokeAsync_InputPortValidatorHasNotBeenRegistered_MovesToNextPipe()
+    public async Task InvokeAsync_InputPortValidatorHasNotBeenRegistered_InvocationFails()
     {
         // Arrange
         this.m_MockServiceFactory.Reset();
 
         // Act
-        await this.m_Pipe.InvokeAsync(this.m_InputPort, this.m_MockOutputPort.Object, this.m_MockServiceFactory.Object, this.m_MockNextPipeHandle.Object, default);
+        var _Exception = await Record.ExceptionAsync(() => this.m_Pipe.InvokeAsync(this.m_InputPort, this.m_MockOutputPort.Object, this.m_MockServiceFactory.Object, this.m_MockNextPipeHandle.Object, default));
 
         // Assert
-        this.m_MockNextPipeHandle.Verify(mock => mock.Invoke(), Times.Once());
+        _ = _Exception.Should().BeOfType<NullReferenceException>();
 
         this.m_MockNextPipeHandle.VerifyNoOtherCalls();
         this.m_MockOutputPort.VerifyNoOtherCalls();

--- a/test/CleanArchitecture.Mediator.Tests/Unit/Internal/InteractorInvocationPipeTests.cs
+++ b/test/CleanArchitecture.Mediator.Tests/Unit/Internal/InteractorInvocationPipeTests.cs
@@ -1,5 +1,7 @@
 ﻿using CleanArchitecture.Mediator.Internal;
+using FluentAssertions;
 using Moq;
+using System;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -32,15 +34,17 @@ public class InteractorInvocationPipeTests
     #region - - - - - - InvokeAsync Tests - - - - - -
 
     [Fact]
-    public async Task InvokeAsync_InteractorDoesNotExist_DoesNothing()
+    public async Task InvokeAsync_InteractorDoesNotExist_InvocationFails()
     {
         // Arrange
         this.m_MockServiceFactory.Reset();
 
         // Act
-        await this.m_Pipe.InvokeAsync(this.m_InputPort, this.m_OutputPort, this.m_MockServiceFactory.Object, this.m_MockNextPipeHandle.Object, default);
+        var _Exception = await Record.ExceptionAsync(() => this.m_Pipe.InvokeAsync(this.m_InputPort, this.m_OutputPort, this.m_MockServiceFactory.Object, this.m_MockNextPipeHandle.Object, default));
 
         // Assert
+        _ = _Exception.Should().BeOfType<NullReferenceException>();
+
         this.m_MockInteractor.VerifyNoOtherCalls();
         this.m_MockNextPipeHandle.VerifyNoOtherCalls();
     }

--- a/test/CleanArchitecture.Mediator.Tests/Unit/Internal/LicencePolicyValidationPipeTests.cs
+++ b/test/CleanArchitecture.Mediator.Tests/Unit/Internal/LicencePolicyValidationPipeTests.cs
@@ -1,5 +1,7 @@
 ﻿using CleanArchitecture.Mediator.Internal;
+using FluentAssertions;
 using Moq;
+using System;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -48,16 +50,16 @@ public class LicencePolicyValidationPipeTests
     #region - - - - - - InvokeAsync Tests - - - - - -
 
     [Fact]
-    public async Task InvokeAsync_ValidatorHasNotBeenRegistered_MovesToNextPipe()
+    public async Task InvokeAsync_ValidatorHasNotBeenRegistered_InvocationFails()
     {
         // Arrange
         this.m_MockServiceFactory.Reset();
 
         // Act
-        await this.m_Pipe.InvokeAsync(this.m_InputPort, this.m_MockOutputPort.Object, this.m_MockServiceFactory.Object, this.m_MockNextPipeHandle.Object, default);
+        var _Exception = await Record.ExceptionAsync(() => this.m_Pipe.InvokeAsync(this.m_InputPort, this.m_MockOutputPort.Object, this.m_MockServiceFactory.Object, this.m_MockNextPipeHandle.Object, default));
 
         // Assert
-        this.m_MockNextPipeHandle.Verify(mock => mock.Invoke(), Times.Once());
+        _ = _Exception.Should().BeOfType<NullReferenceException>();
 
         this.m_MockLicencePolicyValidator.VerifyNoOtherCalls();
         this.m_MockNextPipeHandle.VerifyNoOtherCalls();


### PR DESCRIPTION
This has been done because the effect of unregistered services is far more obvious than the previous behaviour. Previously, the pipes would generally continue, mimicking a successful response. This means that invalid setups previously lead to successful responses, instead of failures.

Missing registrations can easily be found by writing integration tests on the use case, which is preferable to writing unit tests on individual components of the use case. It's preferable because there's a lot of behaviour implemented in the pipes, and the interaction of pipes and their services isn't tested through unit tests alone.

#126